### PR TITLE
Rename class and update example

### DIFF
--- a/Example/NibLoadableView/CustomButton.swift
+++ b/Example/NibLoadableView/CustomButton.swift
@@ -9,7 +9,7 @@
 import Foundation
 import NibLoadableView
 
-class CustomButton: NibLoadbaleControl {
+class CustomButton: NibLoadableControl {
     
     override func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
         

--- a/NibLoadableView/Classes/NibLoadableView.swift
+++ b/NibLoadableView/Classes/NibLoadableView.swift
@@ -122,7 +122,7 @@ open class NibLoadableView: UIView {
  2. Apply constraints if needed.
  3. Set the custom class of the view to your `NibLoadableControl` subclass.
  */
-open class NibLoadbaleControl: UIControl {
+open class NibLoadableControl: UIControl {
     
     open var bundle: Bundle { return Bundle(for: type(of: self)) }
     


### PR DESCRIPTION
Fixes typo `NibLoadbaleControl` -> `NibLoadableControl`